### PR TITLE
Accept custom template file

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ $ curl http://localhost:5984/_all_dbs -s | jq .
 ]
 ```
 
+## Templating
+
 ## Licence
 
 [MIT](https://github.com/eiri/echolalia/blob/master/LICENSE)

--- a/echolalia.py
+++ b/echolalia.py
@@ -141,7 +141,10 @@ def main():
     db_name = args.name if args.name is not None else fake.word()
     create_db(db_name)
     log.info('Populating database with template {}'.format(args.template))
-    template_file = 'templates/{}.json'.format(args.template)
+    if os.path.isfile(args.template):
+      template_file = args.template
+    else:
+      template_file = 'templates/{}.json'.format(args.template)
     log.debug('Reading template {}'.format(template_file))
     with open(template_file) as tpl:
       template = json.load(tpl)


### PR DESCRIPTION
Mark section for templating in README and make the script to check if --template refers to an existing file, treat it as a predefined template otherwise. 

This closes #4 
