### PR TITLE
Support format in attribute

### DIFF
--- a/echolalia.py
+++ b/echolalia.py
@@ -90,12 +90,15 @@ def generate_value(tpl):
   if isinstance(tpl, list):
     value = [generate_value(value) for value in tpl]
   elif 'attr' in tpl:
+    frmt = tpl['frmt']
     attr = tpl['attr']
     args = tpl['args']
     if not hasattr(fake, attr):
       raise ValueError('Unknown fake method {}'.format(attr))
     fun = getattr(fake, attr)
     value = fun(*args)
+    if isinstance(value, (str,unicode)):
+      value = frmt.format(**{attr : value})
   else:
     value = generate_doc(tpl)
   value = normalize_to_json_type(value)
@@ -131,9 +134,11 @@ def do_postprocess(value, pplist):
 
 def preprocess_value(tpl):
   if isinstance(tpl, basestring):
-    post_tpl = {'attr': tpl, 'args': ()}
+    post_tpl = {'frmt': '{{{}}}'.format(tpl), 'attr': tpl, 'args': ()}
   elif isinstance(tpl, dict):
     if 'attr' in tpl:
+      if not 'frmt' in tpl:
+        tpl['frmt'] = '{{{}}}'.format(tpl['attr'])
       if not 'args' in tpl:
         tpl['args'] = ()
       if 'postprocess' in tpl and not isinstance(tpl['postprocess'], list):

--- a/echolalia.py
+++ b/echolalia.py
@@ -134,6 +134,8 @@ def preprocess_value(tpl):
     post_tpl = {'attr': tpl, 'args': ()}
   elif isinstance(tpl, dict):
     if 'attr' in tpl:
+      if not 'args' in tpl:
+        tpl['args'] = ()
       if 'postprocess' in tpl and not isinstance(tpl['postprocess'], list):
         tpl['postprocess'] = [tpl['postprocess']]
       post_tpl = tpl

--- a/templates/people.json
+++ b/templates/people.json
@@ -9,12 +9,11 @@
   "phone": "phone_number",
   "street": "street_address",
   "state": "state",
-  "postcode": "postcode",
+  "postcode": {"attr": "postcode"},
   "tags": [
     "word",
     {
       "attr": "day_of_week",
-      "args": [],
       "postprocess": [
         "lower",
         {

--- a/templates/people.json
+++ b/templates/people.json
@@ -5,11 +5,15 @@
   },
   "age": {"attr" : "random_int", "args": [16, 106]},
   "sex": {"attr" : "random_element", "args": [["M", "F"]]},
+  "single": "boolean",
   "email": "free_email",
   "phone": "phone_number",
   "street": "street_address",
   "state": "state",
-  "postcode": {"attr": "postcode"},
+  "postcode": {
+    "frmt": "ZIP: {postcode}",
+    "attr": "postcode"
+  },
   "tags": [
     "word",
     {

--- a/templates/people.json
+++ b/templates/people.json
@@ -9,7 +9,7 @@
   "email": "free_email",
   "phone": "phone_number",
   "street": "street_address",
-  "state": "state",
+  "state": "{state}, {state_abbr}",
   "postcode": {
     "frmt": "ZIP: {postcode}",
     "attr": "postcode"


### PR DESCRIPTION
If attribute string match standart python string format we'll treat it as such, assuming that variables names in format are according fake's methods that should be passed in as a dictionary.

It's a primitive form of templating but it allows to have combined generated values without dependency on mustach or jinja

This closes #2 
