### PR TITLE
Allow either template or a list of key-value items

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,14 @@ $ ./echolalia.py -c 2 -t templates/people.json -w stdout
 [{"name": {"lastName": "Shannon", "firstName": "Rhonda"}, "tags": ["nihil", "fngheqnl", "impedit", "consequatur"], "age": 30, "state": "Hawaii, AR", "sex": "F", "phone": "03744269231", "single": true, "street": "4081 Sharon Ranch Apt. 197", "postcode": "ZIP: 02709-0053", "times": {"createdAt": "2017-02-13 13:14:08", "updatedAt": "2017-09-23 15:37:29"}, "email": "tiffany87@hotmail.com"}, {"name": {"lastName": "Hanson", "firstName": "Robert"}, "tags": ["quasi", "zbaqnl", "deserunt", "laborum"], "age": 104, "state": "Nevada, FL", "sex": "F", "phone": "(698)292-8761x6944", "single": false, "street": "3898 Alexandria Parkways", "postcode": "ZIP: 24439", "times": {"createdAt": "2017-05-03 03:16:21", "updatedAt": "2017-09-23 15:37:02"}, "email": "zfowler@hotmail.com"}]
 ```
 
-## Teplates
+```bash
+$ ./echolalia.py -c 2 -i name -i email=free_email -f csv
+Bruce Day,lori09@yahoo.com
+Janice Turner,matthew72@sanders.com
+
+```
+
+## Templates
 _TBD_
 
 ## Formatters
@@ -21,7 +28,10 @@ _TBD_
 
 ## Writers
 ### StdOut
-This is a basic plugin that just outputs generated data on standard output.
+This is a basic plugin that just outputs generated data on the standard output.
+
+### File
+Output to a specified with `-o` or `--output` file.
 
 ### CouchDB
 

--- a/echolalia.py
+++ b/echolalia.py
@@ -12,10 +12,12 @@ def add_args():
   parser = argparse.ArgumentParser(
     description='Generate random data for your application')
   parser.add_argument('-w', '--writer', type=str, default='stdout')
-  parser.add_argument('-t', '--template', type=str, required=True)
   parser.add_argument('-f', '--format', type=str, default='json')
   parser.add_argument('-c', '--count', type=int, default=1)
   parser.add_argument('-v', '--verbose', action='store_true')
+  group = parser.add_mutually_exclusive_group(required=True)
+  group.add_argument('-t', '--template', type=str)
+  group.add_argument('-i', '--items', type=str, action='append', metavar='KEY=VALUE')
   return parser
 
 def init_logging(verbose=False):
@@ -50,8 +52,19 @@ def main():
 
   template = args.template
   count = args.count
-  log.debug('Generating {} docs with template {}'.format(count, template))
-  generator = Generator(template)
+  if template is None:
+    log.debug('Generating {} docs with {} item(s)'.format(count, len(args.items)))
+    items = {}
+    for item in args.items:
+      kv = item.split("=", 1)
+      if len(kv) == 2:
+        items[kv[0]] = kv[1]
+      else:
+        items[item] = item
+    generator = Generator(items=items)
+  else:
+    log.debug('Generating {} docs with template {}'.format(count, template))
+    generator = Generator(template=template)
   data = generator.generate(count)
 
   log.debug('Marshalling with formatter "{}"'.format(args.format))


### PR DESCRIPTION
Adds option to specify generated items as a list of `key=value` pairs or just `value` where key will be the same as faker's method.

Closes #33 